### PR TITLE
improve .ref "No poo" error message

### DIFF
--- a/poo.ss
+++ b/poo.ss
@@ -49,6 +49,7 @@
 ;; For a slot of type A
 ;; : (A s) <- (Poo A) s:Symbol ?((A s) <-)
 (def (.ref poo. slot (base no-such-slot))
+  (unless (poo? poo.) (error ".ref: No poo" poo. "slot:" slot))
   (.instantiate poo.)
   (match poo.
     ((poo prototypes instance)


### PR DESCRIPTION
Improve `.ref` "No poo" error message to include the slot it was trying to access.