### PR TITLE
BytesN: improve type-error message for length mismatch

### DIFF
--- a/type.ss
+++ b/type.ss
@@ -78,6 +78,12 @@
 (.def (BytesN. @ [methods.bytes Type.] n)
   sexp: `(BytesN ,n)
   .element?: (λ (x) (and (bytes? x) (= (bytes-length x) n)))
+  .validate: (λ (x (context '()))
+               (unless (bytes? x) (type-error context Type @ [value: x]))
+               (unless (= (bytes-length x) n)
+                 (type-error context Type @ [value: x]
+                   (format "\n  length mismatch: expected ~a, given ~a" n (bytes-length x))))
+               x)
   .sexp<-: (.@ Bytes .sexp<-)
   .length-in-bytes: n
   .zero: (make-bytes n)


### PR DESCRIPTION
This improves an error message
```
type-error Digest [value: #u8(16 254 86 45 121 122 66 220 179 36 144 98 174 149 75 173 6 246 50 128)]
```
Into one that mentions that the problem is a length mismatch, expecting length 32 but given 20
```
type-error Digest [value: #u8(16 254 86 45 121 122 66 220 179 36 144 98 174 149 75 173 6 246 50 128)]
  length mismatch: expected 32, given 20
```