### PR TITLE
import :std/assert

### DIFF
--- a/io.ss
+++ b/io.ss
@@ -2,7 +2,10 @@
 
 (import
   :gerbil/gambit/bytes :gerbil/gambit/hash :gerbil/gambit/ports
-  :std/format :std/generic :std/iter :std/misc/repr :std/sugar :std/assert :std/text/json
+  :std/assert :std/format :std/generic :std/iter
+  :std/misc/repr
+  :std/sugar
+  :std/text/json
   :clan/base :clan/hash :clan/io :clan/json
   ./object ./mop ./brace)
 

--- a/io.ss
+++ b/io.ss
@@ -2,7 +2,7 @@
 
 (import
   :gerbil/gambit/bytes :gerbil/gambit/hash :gerbil/gambit/ports
-  :std/format :std/generic :std/iter :std/misc/repr :std/sugar :std/text/json
+  :std/format :std/generic :std/iter :std/misc/repr :std/sugar :std/assert :std/text/json
   :clan/base :clan/hash :clan/io :clan/json
   ./object ./mop ./brace)
 

--- a/mop.ss
+++ b/mop.ss
@@ -10,7 +10,7 @@
   :clan/syntax
   :gerbil/gambit/bytes :gerbil/gambit/exact :gerbil/gambit/ports
   :std/error :std/format :std/generic :std/iter :std/lazy
-  :std/misc/list :std/misc/repr :std/srfi/1 :std/sugar
+  :std/misc/list :std/misc/repr :std/srfi/1 :std/sugar :std/assert
   :clan/base :clan/error :clan/hash :clan/io :clan/json :clan/list :clan/syntax
   ./object ./brace)
 

--- a/mop.ss
+++ b/mop.ss
@@ -9,8 +9,10 @@
   (for-syntax :std/srfi/1 :clan/syntax)
   :clan/syntax
   :gerbil/gambit/bytes :gerbil/gambit/exact :gerbil/gambit/ports
-  :std/error :std/format :std/generic :std/iter :std/lazy
-  :std/misc/list :std/misc/repr :std/srfi/1 :std/sugar :std/assert
+  :std/assert :std/error :std/format :std/generic :std/iter :std/lazy
+  :std/misc/list :std/misc/repr
+  :std/srfi/1
+  :std/sugar
   :clan/base :clan/error :clan/hash :clan/io :clan/json :clan/list :clan/syntax
   ./object ./brace)
 

--- a/number.ss
+++ b/number.ss
@@ -7,7 +7,10 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/exact :gerbil/gambit/ports :scheme/base
-  :std/iter :std/misc/bytes :std/misc/hash :std/srfi/1 :std/sugar :std/assert
+  :std/assert :std/iter
+  :std/misc/bytes :std/misc/hash
+  :std/srfi/1
+  :std/sugar
   :clan/base :clan/io :clan/number
   ./object ./mop ./brace ./io)
 

--- a/number.ss
+++ b/number.ss
@@ -7,7 +7,7 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/exact :gerbil/gambit/ports :scheme/base
-  :std/iter :std/misc/bytes :std/misc/hash :std/srfi/1 :std/sugar
+  :std/iter :std/misc/bytes :std/misc/hash :std/srfi/1 :std/sugar :std/assert
   :clan/base :clan/io :clan/number
   ./object ./mop ./brace ./io)
 

--- a/t/mop-test.ss
+++ b/t/mop-test.ss
@@ -2,7 +2,11 @@
 
 (import
   :gerbil/gambit/ports
-  :std/format :std/misc/repr :std/sort :std/srfi/13 :std/sugar :std/assert :std/test
+  :std/assert :std/format
+  :std/misc/repr
+  :std/sort
+  :std/srfi/13
+  :std/sugar :std/test
   :clan/assert :clan/base :clan/debug
   ../object ../mop ../number ../type ../brace)
 

--- a/t/mop-test.ss
+++ b/t/mop-test.ss
@@ -2,7 +2,7 @@
 
 (import
   :gerbil/gambit/ports
-  :std/format :std/misc/repr :std/sort :std/srfi/13 :std/sugar :std/test
+  :std/format :std/misc/repr :std/sort :std/srfi/13 :std/sugar :std/assert :std/test
   :clan/assert :clan/base :clan/debug
   ../object ../mop ../number ../type ../brace)
 

--- a/t/type-test.ss
+++ b/t/type-test.ss
@@ -3,7 +3,7 @@
 
 (import
   :gerbil/gambit/ports
-  :std/format :std/sort :std/pregexp :std/srfi/13 :std/sugar :std/test
+  :std/format :std/sort :std/pregexp :std/srfi/13 :std/sugar :std/assert :std/test
   :clan/assert :clan/base
   ../object ../mop ../number ../type)
 

--- a/t/type-test.ss
+++ b/t/type-test.ss
@@ -3,7 +3,9 @@
 
 (import
   :gerbil/gambit/ports
-  :std/format :std/sort :std/pregexp :std/srfi/13 :std/sugar :std/assert :std/test
+  :std/assert :std/format :std/pregexp :std/sort
+  :std/srfi/13
+  :std/sugar :std/test
   :clan/assert :clan/base
   ../object ../mop ../number ../type)
 

--- a/type.ss
+++ b/type.ss
@@ -6,7 +6,7 @@
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/ports
   :std/format :std/iter :std/lazy :std/misc/hash :std/misc/list
-  :std/srfi/1 :std/srfi/43 :std/sugar :std/text/hex :std/text/json
+  :std/srfi/1 :std/srfi/43 :std/sugar :std/assert :std/text/hex :std/text/json
   :clan/assert :clan/base :clan/hash :clan/io :clan/json :clan/list :clan/maybe :clan/number
   :clan/syntax :clan/with-id
   ./object ./mop ./brace ./io ./number)

--- a/type.ss
+++ b/type.ss
@@ -5,8 +5,11 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/ports
-  :std/format :std/iter :std/lazy :std/misc/hash :std/misc/list
-  :std/srfi/1 :std/srfi/43 :std/sugar :std/assert :std/text/hex :std/text/json
+  :std/assert :std/format :std/iter :std/lazy
+  :std/misc/hash :std/misc/list
+  :std/srfi/1 :std/srfi/43
+  :std/sugar
+  :std/text/hex :std/text/json
   :clan/assert :clan/base :clan/hash :clan/io :clan/json :clan/list :clan/maybe :clan/number
   :clan/syntax :clan/with-id
   ./object ./mop ./brace ./io ./number)


### PR DESCRIPTION
After https://github.com/vyzo/gerbil/pull/644, `assert!` has been moved from `:std/sugar` to a new module `:std/assert`, so we need to import `:std/assert`.